### PR TITLE
#163823207 - Add ability to view orders.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "10"
 script:
-  - npm run test
+  - yarn test --coverageReporters=text-lcov | coveralls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 Fast Food Fast frontend. 
 [![Build Status](https://travis-ci.org/arthurarty/fastFoodFast.svg?branch=develop)](https://travis-ci.org/arthurarty/fastFoodFast)
+[![Coverage Status](https://coveralls.io/repos/github/arthurarty/fastFoodFast/badge.svg?branch=develop)](https://coveralls.io/github/arthurarty/fastFoodFast?branch=ft-get-orders-163823207)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "bootstrap": "^4.2.1",
+    "coveralls": "^3.0.2",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",

--- a/src/components/common/NavBar.jsx
+++ b/src/components/common/NavBar.jsx
@@ -10,10 +10,10 @@ const NavBar = () => {
       <div className="collapse navbar-collapse" id="navbarSupportedContent">
         <ul className="navbar-nav mr-auto">
           <li className="nav-item">
-            <a className="nav-link" href="/">Menu</a>
+            <a className="nav-link" href="/menu">Menu</a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="/">Orders</a>
+            <a className="nav-link" href="/order">Orders</a>
           </li>
         </ul>
       </div>

--- a/src/components/orders/orderTable.jsx
+++ b/src/components/orders/orderTable.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+const OrderTable = (props) => {
+  const { orders } = props;
+  console.log(orders);
+  let orderList = [];
+  if (orders !== undefined) {
+    orderList = orders[0];
+  }
+  return (
+    <div className="container">
+      <h2 className="text-center">Orders</h2>
+      <div className="table-responsive">
+        <table className="table" id="menu">
+          <thead>
+            <tr>
+              <th>
+                Menu Id
+              </th>
+              <th>
+                Order Id
+              </th>
+              <th>
+                User Id
+              </th>
+              <th>
+                Quantity
+              </th>
+              <th>
+                Status
+              </th>
+              <th>
+                Created_at
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {orderList && Object.values(orderList).map((item, index) => (
+              <tr key={index}>
+                <td>{item[0].menu_id}</td>
+                <td>{item[0].order_id}</td>
+                <td>{item[0].user_id}</td>
+                <td>{item[0].quantity}</td>
+                <td>{item[0].status}</td>
+                <td>{item[0].created_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default OrderTable;

--- a/src/redux/actions/__tests__/order.test.js
+++ b/src/redux/actions/__tests__/order.test.js
@@ -1,0 +1,24 @@
+import loadOrderSucess from '../orderActions';
+import * as types from '../actionTypes';
+
+describe('menu actions', () => {
+  it('Should return orders', () => {
+    const orders = [
+      [
+        {
+          created_at: '2019-02-08',
+          menu_id: 1,
+          order_id: 1,
+          quantity: 15,
+          status: 'New',
+          user_id: 28,
+        },
+      ],
+    ];
+    const expectedAction = {
+      type: types.LOAD_ORDERS_SUCCESS,
+      orders,
+    };
+    expect(loadOrderSucess(orders)).toEqual(expectedAction);
+  });
+});

--- a/src/redux/actions/orderActions.js
+++ b/src/redux/actions/orderActions.js
@@ -1,0 +1,5 @@
+import * as types from './actionTypes';
+
+export default function loadOrdersSuccess(orders) {
+  return { type: types.LOAD_ORDERS_SUCCESS, orders };
+}

--- a/src/redux/reducers/__tests__/ordersReducer.js
+++ b/src/redux/reducers/__tests__/ordersReducer.js
@@ -1,0 +1,41 @@
+import reducer from '../ordersReducer';
+import * as types from '../../actions/actionTypes';
+
+describe('order reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual([]);
+  });
+
+  it('return orders', () => {
+    expect(
+      reducer([], {
+        type: types.LOAD_ORDERS_SUCCESS,
+        orders: [
+          [
+            {
+              created_at: '2019-02-08',
+              menu_id: 1,
+              order_id: 1,
+              quantity: 15,
+              status: 'New',
+              user_id: 28,
+            },
+          ],
+        ],
+      }),
+    ).toEqual([
+      {
+        0: [
+          {
+            created_at: '2019-02-08',
+            menu_id: 1,
+            order_id: 1,
+            quantity: 15,
+            status: 'New',
+            user_id: 28,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -2,9 +2,10 @@ import { combineReducers } from 'redux';
 import message from './authReducer';
 import loginMessage from './loginReducer';
 import menu from './menuReducer';
+import orders from './ordersReducer';
 
 const rootReducer = combineReducers({
-  message, loginMessage, menu,
+  message, loginMessage, menu, orders,
 });
 
 export default rootReducer;

--- a/src/redux/reducers/ordersReducer.js
+++ b/src/redux/reducers/ordersReducer.js
@@ -1,0 +1,13 @@
+import * as types from '../actions/actionTypes';
+import initalState from './initalState';
+
+export default function ordersReducer(state = initalState.orders, action) {
+  switch (action.type) {
+    case types.LOAD_ORDERS_SUCCESS:
+      return [...state,
+        Object.assign({}, action.orders),
+      ];
+    default:
+      return state;
+  }
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import configureStore from '../redux/store/configureStore';
 import connectedHomeView from '../views/homeView';
 import MenuView from '../views/menuView';
+import OrderView from '../views/orderView';
 
 const store = configureStore();
 
@@ -13,6 +14,7 @@ const Routes = () => (
       <Switch>
         <Route exact path="/" component={connectedHomeView} />
         <Route path="/menu" component={MenuView} />
+        <Route path="/order" component={OrderView} />
       </Switch>
     </Router>
   </Provider>

--- a/src/views/__tests__/orderView.jsx
+++ b/src/views/__tests__/orderView.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { OrderView } from '../orderView';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('signup form', () => {
+  let wrapper;
+
+  const props = {
+    getOrders: jest.fn(),
+    state: {
+    }
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<OrderView {...props} />);
+  });
+  
+  it('should render menu view', () => {
+    expect(wrapper.find('OrderTable')).toBeDefined();
+  });
+
+});

--- a/src/views/homeView.jsx
+++ b/src/views/homeView.jsx
@@ -35,6 +35,7 @@ export class HomeView extends React.Component {
       sessionStorage.setItem('access_token', loginMessage[0][1].access_token);
       loginMessage = [];
       this.props.history.push('/menu');
+      window.location.reload();
     }
   }
 

--- a/src/views/orderView.jsx
+++ b/src/views/orderView.jsx
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import 'msg-notify/dist/notify.css';
+import './notification.css';
+import { bindActionCreators } from 'redux';
+import OrderTable from '../components/orders/orderTable';
+import NavBar from '../components/common/NavBar';
+import { getDataThunk } from '../redux/thunks';
+import loadOrdersSuccess from '../redux/actions/orderActions';
+
+export class OrderView extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      orders: {},
+    };
+  }
+
+  componentDidMount() {
+    const { getOrders } = this.props;
+    getOrders('orders', loadOrdersSuccess);
+  }
+
+  render() {
+    const { orders } = this.props.state;
+    return (
+      <div>
+        <NavBar />
+        <div className="container-fluid">
+          <main role="main" className="col-md-12 ml-sm-auto col-lg-12 px-4">
+            <OrderTable orders={orders} />
+          </main>
+        </div>
+      </div>
+    );
+  }
+}
+
+OrderView.propTypes = {
+  getOrders: PropTypes.func.isRequired,
+};
+
+function mapStateToProps(state) {
+  return {
+    orders: state.orders[0],
+    state,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    getOrders: bindActionCreators(getDataThunk, dispatch),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(OrderView);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,6 +1828,18 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+coveralls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
+  integrity sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==
+  dependencies:
+    growl "~> 1.10.0"
+    js-yaml "^3.11.0"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.7"
+    minimist "^1.2.0"
+    request "^2.85.0"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -3185,6 +3197,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+"growl@~> 1.10.0":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -4294,7 +4311,7 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.0:
+js-yaml@^3.11.0, js-yaml@^3.12.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
@@ -4456,6 +4473,11 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -4568,6 +4590,11 @@ lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-driver@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
+  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 loglevel@^1.4.1:
   version "1.6.1"
@@ -6144,7 +6171,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0:
+request@^2.85.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
**What does this PR do?**
Add ability to view orders. 

**Description of tasks completed**
- Add orders actions and reducers.
- Add tests.
- Add coveralls badge.

**How to manually test?**
- Pull branch `ft-get-orders-163823207`
- Install dependencies. 
- Signup and Login. 
- Click on orders in the menu bar. 

**Relevant stories**
[#163823207](https://www.pivotaltracker.com/story/show/163823207)

**Screenshots**
![image](https://user-images.githubusercontent.com/17021137/52484786-39854680-2bc8-11e9-8a15-380c1f22c48f.png)
